### PR TITLE
Replace annotation types with annotation instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ void main() {
       ..bind(GenericCar)
       ..bind(ElectricCar)
       ..bind(Engine, toFactory: (fuel) => new V8Engine(fuel), inject: [Fuel])
-      ..bind(Engine, toImplementation: ElectricEngine, withAnnotation: Electric)
+      ..bind(Engine, toImplementation: ElectricEngine, withAnnotation: const Electric())
   ]);
   injector.get(GenericCar).drive(); // Vroom...
   injector.get(ElectricCar).drive(); // Hum...

--- a/lib/generation_utils.dart
+++ b/lib/generation_utils.dart
@@ -1,0 +1,34 @@
+library di.generation_utils;
+
+import 'package:analyzer/src/generated/ast.dart';
+
+class _Annotation {
+  final String key;
+  final String constructor;
+
+  _Annotation(this.key, this.constructor);
+}
+
+_Annotation parseAnnotation(FormalParameter formalParameter, Function resolveClassIdentifier) {
+  if (formalParameter.element.metadata.isEmpty) return null;
+
+  final metadata = (formalParameter as NormalFormalParameter).metadata;
+  assert(metadata.length == 1);
+
+  Annotation annotation = metadata.first;
+  var element = annotation.element;
+
+  final clazz = resolveClassIdentifier(element.returnType);
+  final source = annotation.toSource();
+  final args = _annotationArgsToStr(annotation.arguments.arguments, resolveClassIdentifier);
+
+  return new _Annotation(toValidDartId(source), "const $clazz($args)");
+}
+
+String _annotationArgsToStr(NodeList<Expression> args, Function resolveClassIdentifier) {
+  toStr(arg) => (arg is SimpleIdentifier) ? resolveClassIdentifier(arg.staticElement.type) : arg;
+  return args.map(toStr).join(", ");
+}
+
+String toValidDartId(String str) =>
+    str.replaceAll(new RegExp(r"\W+"), "_");

--- a/lib/key.dart
+++ b/lib/key.dart
@@ -16,7 +16,7 @@ class Key {
 
   final Type type;
   /// Optional.
-  final Type annotation;
+  final Object annotation;
   /// Assigned via auto-increment.
   final int id;
 
@@ -44,7 +44,6 @@ class Key {
     if (annotationToKey == null) {
       _typeToAnnotationToKey[type] = annotationToKey = new Map();
     }
-    annotation = _toType(annotation);
     Key key = annotationToKey[annotation];
     if (key == null) {
       annotationToKey[annotation] =
@@ -61,12 +60,6 @@ class Key {
       asString += ' annotated with: $annotation';
     }
     return asString;
-  }
-
-  static Type _toType(obj) {
-    if (obj == null) return null;
-    if (obj is Type) return obj;
-    return obj.runtimeType;
   }
 }
 

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -45,7 +45,12 @@ class NoProviderError extends ResolvingError {
     if (PRIMITIVE_TYPES.contains(root)) {
       return "Cannot inject a primitive type of $root! $resolveChain";
     }
-    return "No provider found for $root! $resolveChain";
+
+    var annotationSuffix = "";
+    if (root.annotation != null) {
+      annotationSuffix = " Make sure the annotation passed to `bind` is a compile-time constant.";
+    }
+    return "No provider found for $root!$annotationSuffix $resolveChain";
   }
 }
 

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -120,7 +120,8 @@ class Module {
    * * [toValue]: The given value will be injected.
    * * [toInstanceOf]: An instance of the given type will be fetched with DI. This is shorthand for
    *   toFactory: (x) => x, inject: [X].
-   * * [withAnnotation]: Type decorated with additional annotation.
+   * * [withAnnotation]: Type decorated with additional annotation. The given value must
+   *   be a compile-time constant.
    *
    * Up to one (0 or 1) of the following parameters can be specified at the
    * same time: [toImplementation], [toFactory], [toValue], [toInstanceOf].
@@ -128,7 +129,7 @@ class Module {
   void bind(Type type, {dynamic toValue: DEFAULT_VALUE,
       Function toFactory: DEFAULT_VALUE, Type toImplementation,
       List inject: const [], toInstanceOf, Object withAnnotation}) {
-    bindByKey(new Key(type, _toType(withAnnotation)), toValue: toValue, toInstanceOf: toInstanceOf,
+    bindByKey(new Key(type, withAnnotation), toValue: toValue, toInstanceOf: toInstanceOf,
         toFactory: toFactory, toImplementation: toImplementation, inject: inject);
   }
 
@@ -143,20 +144,5 @@ class Module {
     binding.bind(key, reflector, toValue: toValue, toFactory: toFactory, toInstanceOf: toInstanceOf,
                  toImplementation: toImplementation, inject: inject);
     bindings[key] = binding;
-  }
-
-  static Type _toType(obj) {
-    if (obj == null) return null;
-    if (obj is Type) {
-      try {
-        throw "ignore";
-      } catch (e,s) {
-        final line = s.toString().split("\n")[2];
-        final location = line.substring(line.indexOf('('));
-        print("DEPRECATED: Use `withAnnotation: const $obj()` instead of `withAnnotation: $obj`. $location");
-      }
-      return obj;
-    }
-    return obj.runtimeType;
   }
 }

--- a/lib/src/reflector_dynamic.dart
+++ b/lib/src/reflector_dynamic.dart
@@ -256,8 +256,8 @@ class DynamicTypeFactories extends TypeReflector {
       }
       ClassMirror pTypeMirror = (p.type as ClassMirror);
       var pType = pTypeMirror.reflectedType;
-      var annotationType = p.metadata.isNotEmpty ? p.metadata.first.type.reflectedType : null;
-      return new Key(pType, annotationType);
+      var annotation = p.metadata.isNotEmpty ? p.metadata.first.reflectee : null;
+      return new Key(pType, annotation);
     }, growable:false);
   }
 

--- a/test/test_annotations.dart
+++ b/test/test_annotations.dart
@@ -11,3 +11,8 @@ class Old {
 class Turbo {
   const Turbo();
 }
+
+class EngineType {
+  final name;
+  const EngineType(this.name);
+}

--- a/test/transformer_test.dart
+++ b/test/transformer_test.dart
@@ -714,8 +714,9 @@ main() {
               'a|web/main.dart': '''
                   import "package:inject/inject.dart";
 
-                  class Turbo {
-                    const Turbo();
+                  class EngineType {
+                    final String value;
+                    const EngineType(this.value);
                   }
 
                   @inject
@@ -723,7 +724,7 @@ main() {
 
                   @inject
                   class Car {
-                    Car(@Turbo() Engine engine);
+                    Car(@EngineType('turbo123!') Engine engine);
                   }
 
                   main() {}
@@ -733,7 +734,7 @@ main() {
               "import 'main.dart' as import_0;",
             ],
             keys: [
-              "Engine_Turbo = new Key(import_0.Engine, import_0.Turbo);"
+              "Engine__EngineType_turbo123_ = new Key(import_0.Engine, const import_0.EngineType('turbo123!'));"
             ],
             factories: [
               'import_0.Engine: () => new import_0.Engine(),',
@@ -741,7 +742,7 @@ main() {
             ],
             paramKeys: [
               'import_0.Engine: const[],',
-              'import_0.Car: [_KEY_Engine_Turbo],'
+              'import_0.Car: [_KEY_Engine__EngineType_turbo123_],'
             ]);
       });
 


### PR DESCRIPTION
Currently `bind` takes an annotation type.

```
bind(SomeClass, withAnnotation: SomeAnnotation)
// this creates  new Key(SomeClass, SomeAnnotation);
```

This means that although you can pass arguments to an annotation, they will be ignored.

```
class SomeClass {
	SomeClass(@Event('change') Function eventEmitter) // the event type is lost
}
```



This PR changes `Key` and `bind` to accept an instance.

```
bind(SomeClass, withAnnotation: const SomeAnnotation())
// this creates new Key(SomeClass, const SomeAnnotation());
```


This makes `@Event('change')` possible and also cleans up existing code. For instance, the following

```
class SomeClass {
	SomeClass(@InjectAddress String address, @InjectName String name)
}
```

can be replaced with

```
class SomeClass {
	SomeClass(@Inject('address') String address, @Inject('name') String name)
}
```

This PR depends on #179. 
Don't merge it until #179 is merged and deployed.