### PR TITLE
Change checkBindArgs to use the equivalent method in smoke.

### DIFF
--- a/lib/check_bind_args.dart
+++ b/lib/check_bind_args.dart
@@ -1,35 +1,19 @@
 library di.check_bind_args;
 
+import 'package:smoke/smoke.dart' as smoke;
+
 import "src/module.dart";
 export "src/module.dart" show DEFAULT_VALUE, IDENTITY, isSet, isNotSet;
 
 checkBindArgs(dynamic toValue, Function toFactory,
               Type toImplementation, List inject, toInstanceOf) {
   int count = 0;
-  bool argCountMatch = true;
   if (isSet(toValue)) count++;
   if (isSet(toFactory)) {
     count++;
-    var len = inject.length;
-    switch (len) {
-      case 0: argCountMatch = toFactory is _0; break;
-      case 1: argCountMatch = toFactory is _1; break;
-      case 2: argCountMatch = toFactory is _2; break;
-      case 3: argCountMatch = toFactory is _3; break;
-      case 4: argCountMatch = toFactory is _4; break;
-      case 5: argCountMatch = toFactory is _5; break;
-      case 6: argCountMatch = toFactory is _6; break;
-      case 7: argCountMatch = toFactory is _7; break;
-      case 8: argCountMatch = toFactory is _8; break;
-      case 9: argCountMatch = toFactory is _9; break;
-      case 10: argCountMatch = toFactory is _10; break;
-      case 11: argCountMatch = toFactory is _11; break;
-      case 12: argCountMatch = toFactory is _12; break;
-      case 13: argCountMatch = toFactory is _13; break;
-      case 14: argCountMatch = toFactory is _14; break;
-      case 15: argCountMatch = toFactory is _15; break;
+    if (!smoke.canAcceptNArgs(toFactory, inject.length)) {
+      throw "toFactory's argument count does not match amount provided by inject";
     }
-    if (!argCountMatch) throw "toFactory's argument count does not match amount provided by inject";
   }
 
   if (toImplementation != null) count++;
@@ -45,22 +29,5 @@ checkBindArgs(dynamic toValue, Function toFactory,
 
   return true;
 }
-
-typedef _0();
-typedef _1(a1);
-typedef _2(a1, a2);
-typedef _3(a1, a2, a3);
-typedef _4(a1, a2, a3, a4);
-typedef _5(a1, a2, a3, a4, a5);
-typedef _6(a1, a2, a3, a4, a5, a6);
-typedef _7(a1, a2, a3, a4, a5, a6, a7);
-typedef _8(a1, a2, a3, a4, a5, a6, a7, a8);
-typedef _9(a1, a2, a3, a4, a5, a6, a7, a8, a9);
-typedef _10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
-typedef _11(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11);
-typedef _12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
-typedef _13(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
-typedef _14(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
-typedef _15(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15);
 
 // Generation script in scripts/check_bind_args_script.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   analyzer: '>=0.22.0 <0.25.0'
   barback: '>=0.15.0 <0.16.0'
   code_transformers: '>=0.2.3 <0.3.0'
+  smoke: '>=0.3.1 <0.4.0'
   path: ">=1.3.0 <2.0.0"
 dev_dependencies:
   benchmark_harness: ">=1.0.4 <2.0.0"


### PR DESCRIPTION
Standardizing all calls to the smoke method will make it easier to generate optimized dart2js code for canAcceptNArgs some timein the near future.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/di.dart/207)

<!-- Reviewable:end -->
