### PR TITLE
Adds missing import for TypeLiteral

### DIFF
--- a/lib/transformer/injector_generator.dart
+++ b/lib/transformer/injector_generator.dart
@@ -398,6 +398,7 @@ library ${id.package}.$libName.generated_type_factory_maps;
 
 import 'package:di/di.dart';
 import 'package:di/src/reflector_static.dart';
+import 'package:di/type_literal.dart';
 
 ''');
 }

--- a/test/transformer_test.dart
+++ b/test/transformer_test.dart
@@ -842,6 +842,7 @@ library a.web.main.generated_type_factory_maps;
 
 import 'package:di/di.dart';
 import 'package:di/src/reflector_static.dart';
+import 'package:di/type_literal.dart';
 ''';
 
 const String CLASS_ENGINE = '''


### PR DESCRIPTION
If there is an injection for a parameterized type, the generated contains a reference to TypeLiteral. However, this doesn't actually work because the appropriate import is missing. This adds the import to the generated code.