### PR TITLE
chore(pubspec): Widen the analyzer constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.4
+
+- Widen dependency on package:analyzer.
+
 # 3.3.3
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Add dependency to your pubspec.yaml.
 
     dependencies:
-      di: ">=3.3.3 <4.0.0"
+      di: ">=3.3.4 <4.0.0"
 
 Then, run `pub install`.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: di
-version: 3.3.3
+version: 3.3.4
 authors:
 - Vojta Jina <vojta.jina@gmail.com>
 - Pavel Jbanov <pavelgj@gmail.com>
@@ -11,7 +11,7 @@ homepage: https://github.com/angular/di.dart
 environment:
   sdk: '>=1.6.0'
 dependencies:
-  analyzer: '>=0.22.0 <0.23.0'
+  analyzer: '>=0.22.0 <0.25.0'
   barback: '>=0.15.0 <0.16.0'
   code_transformers: '>=0.2.3 <0.3.0'
   path: ">=1.3.0 <2.0.0"


### PR DESCRIPTION
Allow use of package:analyzer <0.25.0. Analyzer earlier than 0.24.0 has
issues with parsing `async` and `await`, this allows the use of di
with code that needs process such code with analyzer.