### PR TITLE
fix(tests): workaround matcher bug

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,7 +12,7 @@ dart --checked test/transformer_test.dart
 echo "Building example..."
 rm -rf example/build/
 cd example
-pub_out=$(pub build | tee /dev/tty | grep -F "mirror" || : )
+pub_out=$(pub build | tee /dev/tty | grep "mirror" | grep -v "mirrors_remover" || : )
 cd ..
 echo "--------"
 

--- a/test/main.dart
+++ b/test/main.dart
@@ -14,7 +14,6 @@
 library di.tests;
 
 import 'package:guinness/guinness.dart';
-import 'package:matcher/matcher.dart' as matcher;
 import 'package:di/di.dart';
 import 'package:di/annotations.dart';
 import 'package:di/type_literal.dart';
@@ -788,8 +787,15 @@ createInjectorSpec(String injectorName, ModuleFactory moduleFactory) {
       var parent = new ModuleInjector([moduleFactory()..bind(Engine)]);
       var child = new ModuleInjector([moduleFactory()..bind(MockEngine)], parent);
 
-      expect(parent.types).to(matcher.unorderedEquals([Engine, Injector]));
-      expect(child.types).to(matcher.unorderedEquals([Engine, MockEngine, Injector]));
+      void expectUnorderedEquals(actual, expected) {
+        expect(actual.length).toEqual(expected.length);
+        expected.forEach((item) {
+          expect(actual).toContain(item);
+        });
+      }
+
+      expectUnorderedEquals(parent.types, [Engine, Injector]);
+      expectUnorderedEquals(child.types, [Engine, MockEngine, Injector]);
     });
 
     it('should inject instance from parent if not provided in child', () {


### PR DESCRIPTION
Expects in guinness are not working with matchers. Removes dependency on matcher to work around the issue.

Closes #216, #219