### PR TITLE
chore(pubspec): widen dependency on package:analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.5
+
+- Widen dependency on package:analyzer.
+
 # 3.3.4
 
 - Widen dependency on package:analyzer.

--- a/benchmark/static_injector_baseline_benchmark.dart
+++ b/benchmark/static_injector_baseline_benchmark.dart
@@ -5,7 +5,7 @@ import 'package:di/src/reflector_static.dart';
 import 'injector_benchmark_common.dart';
 import 'static_injector_benchmark.dart';
 
-import 'dart:profiler';
+import 'dart:developer';
 
 /**
  * This benchmark creates the same objects as the StaticInjectorBenchmark

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: di
-version: 3.3.4
+version: 3.3.5
 authors:
 - Vojta Jina <vojta.jina@gmail.com>
 - Pavel Jbanov <pavelgj@gmail.com>
@@ -11,7 +11,7 @@ homepage: https://github.com/angular/di.dart
 environment:
   sdk: '>=1.6.0'
 dependencies:
-  analyzer: '>=0.22.0 <0.25.0'
+  analyzer: '>=0.22.0 <0.27.0'
   barback: '>=0.15.0 <0.16.0'
   code_transformers: '>=0.2.3 <0.3.0'
   path: ">=1.3.0 <2.0.0"


### PR DESCRIPTION
The old analyzer depends on dart:profiler, which is deprecated and will be removed in an upcoming version of dart