### PR TITLE
chore: move to analyzer 0.27.1, guinness2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 packages
+.packages
+.pub
 pubspec.lock
 .idea
 test/type_factories_gen.dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.3.6
+
+- Move to analyzer 0.27.1
+- Move to guinness2
+
 # 3.3.5+1
 
 ## Bug fix
@@ -340,4 +345,3 @@ StaticInjectorBenchmark(RunTime): 291.9281856663261 us.
   - skip _checkKeyConditions in dart2js
   ([6763552a](https://github.com/angular/di.dart/commit/6763552adccdc41ef1043930ea50e0425509e6c5))
   - +29%. Use an array for type lookup instead of a map.
-

--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -1,6 +1,5 @@
 import 'package:di/di.dart';
 import 'package:di/annotations.dart';
-import 'dart:html';
 
 @Injectable()
 class Application {

--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -363,7 +363,7 @@ class SourceCrawler {
       entryPointImport = entryPointFile.getAbsolutePath();
     }
 
-    Source source = new FileBasedSource.con1(entryPointFile);
+    Source source = new FileBasedSource(entryPointFile);
     ChangeSet changeSet = new ChangeSet();
     changeSet.addedSource(source);
     context.applyChanges(changeSet);

--- a/lib/transformer/injector_generator.dart
+++ b/lib/transformer/injector_generator.dart
@@ -135,7 +135,7 @@ class _Processor {
       var annotationIdx = 0;
       for (var annotation in lib.metadata) {
         if (annotation.element == injectablesCtor) {
-          var libDirective = lib.definingCompilationUnit.node.directives
+          var libDirective = lib.definingCompilationUnit.computeNode().directives
               .where((d) => d is LibraryDirective).single;
           var annotationDirective = libDirective.metadata[annotationIdx];
           var listLiteral = annotationDirective.arguments.arguments.first;
@@ -273,9 +273,6 @@ class _Processor {
    */
   String _generateInjectLibrary(Iterable<ConstructorElement> constructors) {
     var prefixes = <LibraryElement, String>{};
-
-    var ctorTypes = constructors.map((ctor) => ctor.enclosingElement).toSet();
-
     var usedLibs = new Set<LibraryElement>();
     String resolveClassName(ClassElement type, [List<DartType> typeArgs]) {
       var library = type.library;
@@ -316,7 +313,7 @@ class _Processor {
               (item) => item.element.returnType.element);
         }
 
-        var keyName = '_KEY_${param.type.name}' + (annotations.isNotEmpty ? '_${annotations.first}' : '');
+        var keyName = '_KEY_${param.type.name}' + (annotations.isNotEmpty ? '_${annotations.first.name}' : '');
         var typeArgs = param.type.typeArguments;
         if (typeArgs != null && typeArgs.isNotEmpty && typeArgs.any((arg) => arg is! DynamicTypeImpl)) {
           typeArgs.forEach((arg) => keyName = ('${keyName}_${arg.name}'));
@@ -361,7 +358,7 @@ class _Processor {
   void _editMain() {
     AssetId id = transform.primaryInput.id;
     var lib = resolver.getLibrary(id);
-    var unit = lib.definingCompilationUnit.node;
+    var unit = lib.definingCompilationUnit.computeNode();
     var transaction = resolver.createTextEditTransaction(lib);
 
     var imports = unit.directives.where((d) => d is ImportDirective);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: di
-version: 3.3.5+1
+version: 3.3.6
 authors:
 - Vojta Jina <vojta.jina@gmail.com>
 - Pavel Jbanov <pavelgj@gmail.com>
@@ -11,13 +11,14 @@ homepage: https://github.com/angular/di.dart
 environment:
   sdk: '>=1.6.0'
 dependencies:
-  analyzer: '>=0.22.0 <0.27.0'
+  analyzer: '>=0.27.1 <0.28.0'
   barback: '>=0.15.0 <0.16.0'
-  code_transformers: '>=0.2.3 <0.3.0'
+  code_transformers: '>=0.3.1 <0.4.0'
   path: ">=1.3.0 <2.0.0"
 dev_dependencies:
   benchmark_harness: ">=1.0.4 <2.0.0"
-  guinness: '>=0.1.16 <0.2.0'
+  guinness2: '>=0.0.3 <1.0.0'
   matcher: '>=0.11.0 <0.13.0'
+  test: '>=0.12.7 <0.13.0'
 transformers:
 - di/module_transformer

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,7 +12,7 @@ dart --checked test/transformer_test.dart
 echo "Building example..."
 rm -rf example/build/
 cd example
-pub_out=$(pub build | tee /dev/tty | grep -F "mirror" || : )
+pub_out=$(pub build 2>&1 | tee /dev/tty | grep -F "dart:mirrors" || : )
 cd ..
 echo "--------"
 

--- a/test/main.dart
+++ b/test/main.dart
@@ -13,7 +13,7 @@
 ])
 library di.tests;
 
-import 'package:guinness/guinness.dart';
+import 'package:guinness2/guinness2.dart';
 import 'package:matcher/matcher.dart' as matcher;
 import 'package:di/di.dart';
 import 'package:di/annotations.dart';

--- a/test/transformer_test.dart
+++ b/test/transformer_test.dart
@@ -9,7 +9,7 @@ import 'package:di/transformer.dart';
 import 'package:di/transformer/options.dart';
 import 'package:di/transformer/injector_generator.dart';
 
-import 'package:guinness/guinness.dart';
+import 'package:guinness2/guinness2.dart';
 
 main() {
   describe('transformer', () {


### PR DESCRIPTION
Bonus: build script and .gitignore cleanups

BREAKING CHANGES:

- nothing is breaking in `di.dart`, but `analyzer-0.27.1` contains breaking changes so this version may break people transitively
