### PR TITLE
Remove use of deprecated analyzer setter `AnalysisOptionsImpl.cacheSi…

### DIFF
--- a/lib/generator.dart
+++ b/lib/generator.dart
@@ -342,7 +342,6 @@ class SourceCrawler {
     DartSdk sdk = DirectoryBasedDartSdk.defaultSdk;
 
     AnalysisOptionsImpl contextOptions = new AnalysisOptionsImpl();
-    contextOptions.cacheSize = 256;
     contextOptions.preserveComments = preserveComments;
     contextOptions.analyzeFunctionBodies = false;
     context.analysisOptions = contextOptions;


### PR DESCRIPTION
…ze`.

This analysis option has had no effect for quite some time, and is being removed from the analyzer.